### PR TITLE
Remember whether or not to delete prod value

### DIFF
--- a/commands/pull.js
+++ b/commands/pull.js
@@ -8,10 +8,6 @@ const findKey = require('lodash.findkey')
 const merge = require('../util/merge')
 const file = require('../util/file')
 
-// function hasProdValue (obj) {
-//   .indexOf('production') >= 0
-// }
-
 function * pull (context, heroku) {
   let fname = context.flags.file // this gets defaulted in read
   let config = yield {
@@ -22,8 +18,7 @@ function * pull (context, heroku) {
 
   const prodVal = values(res).find(i => i.match(/^prod/i))
 
-  if (prodVal && (yield file.shouldDeleteProd(context))) {
-    // only check settings if needed, cant yield with && ?
+  if (prodVal && (yield file.shouldDeleteProd(context, prodVal))) {
     const k = findKey(res, i => i === prodVal)
     delete res[k]
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/xavdidtheshadow/heroku-config#readme",
   "dependencies": {
-    "heroku-cli-util": "6.0.15",
+    "heroku-cli-util": "xavdid/heroku-cli-util",
     "lodash.assign": "4.1.0",
     "lodash.findkey": "^4.6.0",
     "lodash.values": "^4.3.0",
@@ -33,6 +33,7 @@
     "chai-as-promised": "^5.3.0",
     "mocha": "^3.0.2",
     "mock-fs": "^3.11.0",
+    "mock-stdin": "^0.3.0",
     "nock": "^8.0.0",
     "rewire": "^2.5.1",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "dependencies": {
     "heroku-cli-util": "6.0.15",
     "lodash.assign": "4.1.0",
+    "lodash.findkey": "^4.6.0",
+    "lodash.values": "^4.3.0",
     "mz": "2.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "homepage": "https://github.com/xavdidtheshadow/heroku-config#readme",
   "dependencies": {
     "heroku-cli-util": "xavdid/heroku-cli-util",
-    "lodash.assign": "4.1.0",
-    "lodash.findkey": "^4.6.0",
-    "lodash.values": "^4.3.0",
+    "lodash.assign": "4.2.0",
+    "lodash.findkey": "4.6.0",
+    "lodash.values": "4.3.0",
     "mz": "2.4.0"
   },
   "devDependencies": {
@@ -37,6 +37,6 @@
     "nock": "^8.0.0",
     "rewire": "^2.5.1",
     "rimraf": "^2.5.2",
-    "standard": "^7.0.0"
+    "standard": "^8.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -129,6 +129,7 @@ describe('Reading', () => {
 
   afterEach(() => {
     mock.restore()
+    cli.mockConsole(false)
   })
 })
 
@@ -162,6 +163,7 @@ describe('Writing', () => {
 
   afterEach(() => {
     mock.restore()
+    cli.mockConsole(false)
   })
 })
 
@@ -177,7 +179,7 @@ describe('Transforming', () => {
 
 describe('Checking for Prod', () => {
   beforeEach(() => {
-    cli.mockPrompt()
+    cli.mockConsole()
     // mock(defaultFS())
   })
 
@@ -196,7 +198,8 @@ describe('Checking for Prod', () => {
   })
 
   afterEach(() => {
-    mock.restore()
+    // mock.restore()
+    cli.mockConsole(false)
   })
 })
 
@@ -233,6 +236,7 @@ describe('Pushing', () => {
 
   afterEach(() => {
     mock.restore()
+    cli.mockConsole(false)
   })
 })
 
@@ -263,5 +267,6 @@ describe('Pulling', () => {
 
   afterEach(() => {
     mock.restore()
+    cli.mockConsole(false)
   })
 })

--- a/test.js
+++ b/test.js
@@ -32,6 +32,7 @@ function fetchCMD (name) {
 
 function setup () {
   cli.raiseErrors = true
+  process.env.NODE_ENV = 'test'
 }
 
 function defaultFS () {

--- a/test.js
+++ b/test.js
@@ -32,7 +32,6 @@ function fetchCMD (name) {
 
 function setup () {
   cli.raiseErrors = true
-  process.env.NODE_ENV = 'test'
 }
 
 function defaultFS () {
@@ -178,7 +177,7 @@ describe('Transforming', () => {
 
 describe('Checking for Prod', () => {
   beforeEach(() => {
-    // cli.mockConsole()
+    cli.mockPrompt()
     // mock(defaultFS())
   })
 
@@ -197,7 +196,7 @@ describe('Checking for Prod', () => {
   })
 
   afterEach(() => {
-    // mock.restore()
+    mock.restore()
   })
 })
 

--- a/util/file.js
+++ b/util/file.js
@@ -78,7 +78,7 @@ module.exports = {
     }
 
     if (settings[context.app] === undefined) {
-      let answer = yield cli.prompt(question, {quiet: true})
+      let answer = yield cli.prompt(question, { quiet: process.env.NODE_ENV === 'test' })
       answer = answer.toLowerCase()
 
       if (answer === 'd' || answer === 'delete') {

--- a/util/file.js
+++ b/util/file.js
@@ -37,12 +37,14 @@ function objFromFileFormat (s, quiet) {
   return res
 }
 
-const question = [
-  'Your config has a value called "production", which is usually pulled in error.',
-  'Should we:',
-  '[d]elete | [i]gnore | [a]lways (delete) | [n]ever (delete)',
-  'that key/value pair for this app?'
-].join('\n\n')
+function question (val) {
+  return [
+    `Your config has a value called "${val}", which is usually pulled in error.`,
+    'Should we:',
+    '[d]elete | [i]gnore | [a]lways (delete) | [n]ever (delete)',
+    'that key/value pair for this app?'
+  ].join('\n\n')
+}
 
 module.exports = {
   read: (fname, quiet) => {
@@ -65,21 +67,20 @@ module.exports = {
       return Promise.reject(new Error(`Error writing to file "${fname}" (${err.message})`))
     })
   },
-  shouldDeleteProd: function * (context) {
+  shouldDeleteProd: function * (context, val) {
     const path = require('path')
 
-    const settingsUrl = path.join(process.env['HOME'], '.heroku_config_settings.json')
+    const settingsUrl = path.join(process.env.HOME, '.heroku_config_settings.json')
 
     let settings
     try {
-      settings = require(settingsUrl)
+      settings = JSON.parse(fs.readFileSync(settingsUrl, 'utf-8'))
     } catch (e) {
       settings = {}
     }
 
     if (settings[context.app] === undefined) {
-      let answer = yield cli.prompt(question)
-      answer = answer.toLowerCase()
+      let answer = (yield cli.prompt(question(val))).toLowerCase()
 
       if (answer === 'd' || answer === 'delete') {
         return true

--- a/util/file.js
+++ b/util/file.js
@@ -78,7 +78,7 @@ module.exports = {
     }
 
     if (settings[context.app] === undefined) {
-      let answer = yield cli.prompt(question, { quiet: process.env.NODE_ENV === 'test' })
+      let answer = yield cli.prompt(question)
       answer = answer.toLowerCase()
 
       if (answer === 'd' || answer === 'delete') {

--- a/util/file.js
+++ b/util/file.js
@@ -78,7 +78,7 @@ module.exports = {
     }
 
     if (settings[context.app] === undefined) {
-      let answer = yield cli.prompt(question)
+      let answer = yield cli.prompt(question, {quiet: true})
       answer = answer.toLowerCase()
 
       if (answer === 'd' || answer === 'delete') {

--- a/util/file.js
+++ b/util/file.js
@@ -37,6 +37,13 @@ function objFromFileFormat (s, quiet) {
   return res
 }
 
+const question = [
+  'Your config has a value called "production", which is usually pulled in error.',
+  'Should we:',
+  '[d]elete | [i]gnore | [a]lways (delete) | [n]ever (delete)',
+  'that key/value pair for this app?'
+].join('\n\n')
+
 module.exports = {
   read: (fname, quiet) => {
     fname = fname || DEFAULT_FNAME
@@ -57,5 +64,40 @@ module.exports = {
     }).catch((err) => {
       return Promise.reject(new Error(`Error writing to file "${fname}" (${err.message})`))
     })
+  },
+  shouldDeleteProd: function * (context) {
+    const path = require('path')
+
+    const settingsUrl = path.join(process.env['HOME'], '.heroku_config_settings.json')
+
+    let settings
+    try {
+      settings = require(settingsUrl)
+    } catch (e) {
+      settings = {}
+    }
+
+    if (settings[context.app] === undefined) {
+      let answer = yield cli.prompt(question)
+      answer = answer.toLowerCase()
+
+      if (answer === 'd' || answer === 'delete') {
+        return true
+      } else if (answer === 'i' || answer === 'ignore') {
+        return false
+      } else if (answer === 'a' || answer === 'always') {
+        settings[context.app] = true
+        fs.writeFileSync(settingsUrl, JSON.stringify(settings))
+        return true
+      } else if (answer === 'n' || answer === 'never') {
+        settings[context.app] = false
+        fs.writeFileSync(settingsUrl, JSON.stringify(settings))
+        return false
+      } else {
+        cli.exit(1, 'Invalid command. Use one of [d|i|a|n] instead')
+      }
+    } else {
+      return settings[context.app]
+    }
   }
 }


### PR DESCRIPTION
Sometimes, you pull a config that has a value "production", which is usually an accident. This PR flags that, plus gives you the option to delete it. 

It also introduces settings (in the form of a json stored in `~`) to remember if you should always or never delete the prod value. 

This'll get merged and released as a semver.minor once https://github.com/heroku/heroku-cli-util/pull/78 gets merged. Without it, my tests are ugly. 