### PR TITLE
specify files to pack to avoid oclif warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     "semver": "^5.3.0",
     "standard": "^9.0.0"
   },
+  "files": [
+    "/index.js",
+    "/commands",
+    "/util"
+  ],
   "prettier": {
     "semi": false,
     "singleQuote": true


### PR DESCRIPTION
this attribute is now required in plugins otherwise a warning is displayed (though notably, the plugins still work fine with the warning)

See my blog post for the reason why this is now required: https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d

for other plugins, if you run `npm pack; tar -xvzf *.tgz; rm -rf package *.tgz` that will print the files it's currently packing