### PR TITLE
Fix clean flag

### DIFF
--- a/commands/push.js
+++ b/commands/push.js
@@ -55,7 +55,8 @@ function* push(context, heroku) {
       context,
       heroku,
       nullKeys,
-      'Successfully deleted unused settings from Heroku!'
+      'Successfully deleted unused settings from Heroku!',
+      pullUrl
     )
   }
 }


### PR DESCRIPTION
Running `heroku config:push --expanded --overwrite --file=app.env --clean --app my-app` fails with

```
http --> PATCH undefined +2ms
--> PATCH /
    ...
http <-- PATCH undefined
http {"id":"not_found","message":"The requested API endpoint was not found. Are you using the right HTTP verb (i.e. `GET` vs. `POST`), and did you specify your intended version with the `Accept` header?"} +285ms
  ...
<-- {"id":"not_found","message":"The requested API endpoint was not found. Are you using the right HTTP verb (i.e. `GET` vs. `POST`), and did you specify your intended version with the `Accept` header?"}
 ▸    The requested API endpoint was not found. Are you using the right HTTP verb (i.e. `GET` vs. `POST`), and did you specify your intended version with the
 ▸    `Accept` header?
```